### PR TITLE
28625119 Puppet ldap resource does create wrong escapes for service_s…

### DIFF
--- a/lib/puppet_x/oracle/solaris_providers/util/svcs.rb
+++ b/lib/puppet_x/oracle/solaris_providers/util/svcs.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2106, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ module PuppetX::Oracle::SolarisProviders::Util::Svcs
 
   def svcs_escape(value=self)
     if value.kind_of? String
-      value.gsub(/([;&()|^<>\n \t\\\"\'`~*\[\]\$\!])/, '\\\\\1')
+      value.gsub(/([;|^<>\n\t\\\"\'`~\[\]\$\!])/, '\\\\\1')
     else
       value
     end


### PR DESCRIPTION
…earch_descriptor

svccfg setprop does not require escaping special characters as long as a
property value of type string/string array is enclosed within
single quotes or double quotes. This fix removes those special characters that
caused some of the network services to fail, from gsub() regular expression.